### PR TITLE
Action server for calculating average engagement per second for a given time range

### DIFF
--- a/ros/launch/person_state_estimation.launch
+++ b/ros/launch/person_state_estimation.launch
@@ -3,8 +3,10 @@
     <arg name="debug" default="true" />
     <arg name="face_feature_topic" default="/migrave_perception/openface_ros/faces" />
     <arg name="of_debug_img_topic" default="/migrave_perception/openface_ros/debug_image" />
+    <arg name="avg_engagement_estimation_server_name" default="/migrave_perception/get_avg_engagement" />
+    <arg name="engagement_cache_seconds" default="300.0" />
 
-    <node pkg="migrave_person_state_estimation" type="person_state_estimator" name="person_state_estimator" output="screen" 
+    <node pkg="migrave_person_state_estimation" type="person_state_estimator" name="person_state_estimator" output="screen"
      ns="migrave_perception" >
         <param name="config_path" type="str" value="$(find migrave_person_state_estimation)/ros/config/person_state_estimation_config.yaml" />
         <param name="face_feature_topic" type="str" value="$(arg face_feature_topic)" />
@@ -13,5 +15,7 @@
         <param name="game_performance_topic" type="str" value="/game_performance" />
         <param name="debug" type="bool" value="$(arg debug)" />
         <param name="of_debug_img_topic" type="str" value="$(arg of_debug_img_topic)" />
+        <param name="avg_engagement_estimation_server_name" type="str" value="$(arg avg_engagement_estimation_server_name)" />
+        <param name="engagement_cache_seconds" type="double" value="$(arg engagement_cache_seconds)" />
     </node>
 </launch>

--- a/ros/src/migrave_person_state_estimation_wrapper/person_state_estimation_wrapper.py
+++ b/ros/src/migrave_person_state_estimation_wrapper/person_state_estimation_wrapper.py
@@ -1,18 +1,24 @@
 import os
+from collections import deque
 
 import cv2
 import numpy as np
 import rospy
-from cv_bridge import CvBridge, CvBridgeError
-from migrave_common import file_utils
-from migrave_person_state_estimation.person_state_estimation import \
-    PersonStateEstimation
-from migrave_ros_msgs.msg import (AffectiveState, AudioFeatures, Faces,
-                                  OverallGamePerformance, Person)
+from cv_bridge import CvBridge
+
 from rospkg import RosPack
 from sensor_msgs.msg import Image
 from std_msgs.msg import String
+from actionlib import SimpleActionServer
 
+from migrave_common import file_utils
+from migrave_ros_msgs.msg import (AffectiveState, AudioFeatures, Faces,
+                                  OverallGamePerformance, Person,
+                                  GetAverageEngagementAction,
+                                  GetAverageEngagementGoal,
+                                  GetAverageEngagementResult)
+from migrave_person_state_estimation.person_state_estimation import \
+    PersonStateEstimation
 
 MIGRAVE_AU_NAMES = ['AU01', 'AU02', 'AU04', 'AU05', 'AU06',
                     'AU07', 'AU09', 'AU10', 'AU12', 'AU14',
@@ -52,15 +58,31 @@ class PersonStateEstimationWrapper(object):
 
         self._cvbridge = CvBridge()
 
+        self._engagement_cache_duration_seconds = rospy.get_param("~engagement_cache_seconds", 5.)
+        self._engagement_estimate_cache = {}
+
+        self._avg_engagement_estimation_server_name = rospy.get_param("~avg_engagement_estimation_server_name",
+                                                                      "/migrave/get_avg_engagement")
+        self._avg_engagement_estimation_server = SimpleActionServer(self._avg_engagement_estimation_server_name,
+                                                                    GetAverageEngagementAction,
+                                                                    self.get_avg_engagement)
+
     def face_feature_cb(self, data: Faces) -> None:
         rospy.logdebug("Face feature msg received")
         for i, face in enumerate(data.faces):
+            # we inititialise an engagement queue for the current
+            # user if one doesn't already exits
+            if i not in self._engagement_estimate_cache:
+                self._engagement_estimate_cache[i] = deque()
+
+            # we retrieve features required for engagement estimation
             auc_dict = {}
             for ac in face.action_units:
                 auc_dict[ac.name] = ac.presence
 
             face_features = []
             for au_name in MIGRAVE_AU_NAMES:
+                # we format the name of the AU feature as expected by the classifier
                 au_feature_name = f'of_{au_name}_c'
                 face_features.append((au_feature_name, auc_dict[au_name]))
 
@@ -69,7 +91,7 @@ class PersonStateEstimationWrapper(object):
             face_features.append(('of_gaze_0_y', face.left_gaze.position.y))
             face_features.append(('of_gaze_0_z', face.left_gaze.position.z))
 
-            # right gaze: of_gaze_0_x, ..y, ..z
+            # right gaze: of_gaze_1_x, ..y, ..z
             face_features.append(('of_gaze_1_x', face.right_gaze.position.x))
             face_features.append(('of_gaze_1_y', face.right_gaze.position.y))
             face_features.append(('of_gaze_1_z', face.right_gaze.position.z))
@@ -106,6 +128,25 @@ class PersonStateEstimationWrapper(object):
             # Publish affective_state
             self._pub_affective_state.publish(affective_state)
 
+            # we update the engagement estimate cache for the current user
+            engagement_estimate_time = rospy.Time.now().to_sec()
+            if self._engagement_estimate_cache[i]:
+                # we clean old entries in the cache (older than the maximum cache duration)
+                clean_cache = True
+                while clean_cache:
+                    time_diff_to_first_estimate = (engagement_estimate_time - self._engagement_estimate_cache[i][0][0])
+                    if time_diff_to_first_estimate > self._engagement_cache_duration_seconds:
+                        self._engagement_estimate_cache[i].popleft()
+
+                        # we stop if the cache is empty after removing the element removal
+                        if not self._engagement_estimate_cache[i]:
+                            clean_cache = False
+                    else:
+                        clean_cache = False
+            self._engagement_estimate_cache[i].append((engagement_estimate_time,
+                                                       engagement_score))
+
+            # we publish a debug image for visualising the engagement score
             if self._debug:
                 rospy.logdebug("Engagement %f", engagement_score)
                 cv_image = self._cvbridge.imgmsg_to_cv2(face.debug_image, "bgr8")
@@ -139,6 +180,48 @@ class PersonStateEstimationWrapper(object):
             self._sub_face_feature.unregister()
             event_out_data.data = "e_stopped"
             self._pub_event.publish(event_out_data)
+
+    def get_avg_engagement(self, goal: GetAverageEngagementGoal) -> None:
+        result = GetAverageEngagementResult()
+
+        # ideally, the user ID should be passed on with the message, but we now
+        # assume that we only have one user that can be seen; we return an empty
+        # result if no engagement estimates have been made thus far
+        if 0 not in self._engagement_estimate_cache or not self._engagement_estimate_cache[0]:
+            rospy.logwarn(f"[get_avg_engagement] No engagement estimates for average calculation")
+            self._avg_engagement_estimation_server.set_succeeded(result)
+            return
+
+        # we create a copy of the cache so that we work with a "frozen" cache version
+        # rather than one that might be changed while the cache is being read
+        raw_engagement_estimates = list(self._engagement_estimate_cache[0])
+        estimates_within_time_range = [(t, e) for (t, e) in raw_engagement_estimates
+                                       if goal.start_time <= t <= goal.end_time]
+
+        # we return an empty result if there are no engagement estimates
+        # within the specified time range
+        if not estimates_within_time_range:
+            rospy.logwarn(f"[get_avg_engagement] No estimates within range {goal.start_time} - {goal.end_time}")
+            self._avg_engagement_estimation_server.set_succeeded(result)
+            return
+
+        # we estimate the average engagement for each second within the given time range
+        rospy.loginfo(f"[get_avg_engagement] Calculating average engagement values between {goal.start_time} - {goal.end_time}")
+        estimate_idx = 0
+        current_first_estimate_idx = 0
+        while estimate_idx < len(estimates_within_time_range):
+            time_diff = estimates_within_time_range[estimate_idx][0] - estimates_within_time_range[current_first_estimate_idx][0]
+            if time_diff > 1:
+                s = sum([e for _, e in estimates_within_time_range[current_first_estimate_idx:estimate_idx]])
+                avg = s / (estimate_idx - current_first_estimate_idx)
+
+                result.timestamps.append(estimates_within_time_range[estimate_idx-1][0])
+                result.avg_engagement.append(avg)
+                current_first_estimate_idx = estimate_idx
+            estimate_idx += 1
+
+        rospy.loginfo("[get_avg_engagement] Done calculating; setting result")
+        self._avg_engagement_estimation_server.set_succeeded(result)
 
     def initialize(self) -> None:
         #start event in and out


### PR DESCRIPTION
### Summary of changes

This PR adds an action server to the person state estimation wrapper, which estimates the average engagement for each second over a given time range. For performing this calculation, the wrapper maintains a cache of engagement estimates over a predefined time period.

The action server is of type [GetAverageEngagement](https://github.com/migrave/migrave_ros_msgs/blob/main/actionlib/GetAverageEngagement.action), an action that was added in `migrave_ros_msgs`.

### Need for the changes

The average engagement calculation is required by the behaviour model described in

`M. Stolarz, A. Mitrevski, M. Wasil, and P. G. Plöger, “Personalised Robot Behaviour Modelling for Robot-Assisted Therapy in the Context of Autism Spectrum Disorder,” in *RO-MAN Workshop on Behavior Adaptation and Learning for Assistive Robotics (BAILAR)*, 2022. Available: https://arxiv.org/abs/2207.12144`

cc @Intelwi 